### PR TITLE
Update RNCustomKeyboardKit.podspec to fix missing homepage.

### DIFF
--- a/ios/RNCustomKeyboardKit.podspec
+++ b/ios/RNCustomKeyboardKit.podspec
@@ -1,24 +1,20 @@
+require 'json'
+  
+package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
 
 Pod::Spec.new do |s|
   s.name         = "RNCustomKeyboardKit"
-  s.version      = "1.0.0"
-  s.summary      = "RNCustomKeyboardKit"
-  s.description  = <<-DESC
-                  RNCustomKeyboardKit
-                   DESC
-  s.homepage     = "https://github.com/themodernjavascript/react-native-custom-keyboard-kit"
-  s.license      = "MIT"
-  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
-  s.author             = { "author" => "author@domain.cn" }
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.license      = package['license']
+
+  s.authors      = package['author']
+  s.homepage     = package['homepage']
+
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/author/RNCustomKeyboardKit.git", :tag => "master" }
-  s.source_files = "*.{h,m}"
+  s.source_files  = "RNCustomKeyboardKit/**/*.{h,m}"
   s.requires_arc = true
 
-
   s.dependency "React"
-  #s.dependency "others"
-
 end
-
-  


### PR DESCRIPTION
fix this error:
[!] The `RNCustomKeyboardKit` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
![image](https://user-images.githubusercontent.com/16468611/83800325-22d7ee00-a65c-11ea-8fcf-dece99d4f747.png)
